### PR TITLE
expose the call for papers blogpost (with the correct shortlink in it…

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,5 +1,6 @@
 {
   "projects": {
-    "default": "devfest-nl-staging"
+    "default": "devfest-nl-staging",
+    "production": "devfest-nl"
   }
 }

--- a/data/blog.json
+++ b/data/blog.json
@@ -7,5 +7,14 @@
     "secondaryColor": "#00BCD4",
     "image": "/images/posts/2015-outside.jpg",
     "brief": "We're are proud to announce the fifth annual GDG DevFest NL 2017&mdash;the biggest Google related event in The Netherlands, carefully crafted by the GDG community! The event will take place on **November 18th** in Amsterdam."
+  },
+  {
+    "id": "calling-all-papers",
+    "title": "Call for papers!",
+    "posted": "2017-08-14",
+    "primaryColor": "#00BCD4",
+    "secondaryColor": "#00BCD4",
+    "image": "/images/posts/2015-outside.jpg",
+    "brief": "GDG DevFest The Netherlands 2017 has been announced! The fifth annual edition of the biggest conference about Google technologies in the Netherlands will take on **November 18th** in Amsterdam."
   }
 ]

--- a/data/en/resources.json
+++ b/data/en/resources.json
@@ -65,7 +65,7 @@
   "featured-videos-view-all": "View all videos",
   "featured-people-title": "Rockstar Speakers",
   "featured-people-view-all": "View all speakers",
-  "action-title": "An impression of 2015's GDG DevFest",
+  "action-title": "An impression of 2016's GDG DevFest",
   "action": "See what GDG DevFest is all about",
   "location-title": "The Faculty of Science",
   "location-description": "Join us at the University of Amsterdam (UvA)",

--- a/data/hoverboard.config.json
+++ b/data/hoverboard.config.json
@@ -65,7 +65,7 @@
     "buttons": [
       {
         "route": "buy-ticket",
-        "url": "https://devfestnl16.eventbrite.com/?aff=www#tickets",
+        "url": "https://devfestnl17.eventbrite.com/?aff=www#tickets",
         "target": "_blank"
       }
     ]
@@ -114,7 +114,7 @@
     ]
   },
   "tickets": {
-    "url": "https://devfestnl16.eventbrite.com/?aff=www#tickets",
+    "url": "https://devfestnl17.eventbrite.com/?aff=www#tickets",
     "elements": [
       {
         "name": "early-ticket",
@@ -148,7 +148,7 @@
       "caption": "days"
     },
     {
-      "counter": 20,
+      "counter": 16+,
       "caption": "sessions"
     },
     {
@@ -162,11 +162,6 @@
       "name": "twitter",
       "nickname": "DevFestNL",
       "url": "https://twitter.com/devfestnl"
-    },
-    {
-      "name": "gplus",
-      "nickname": "113182948271879290904",
-      "url": "https://plus.google.com/113182948271879290904"
     },
     {
       "name": "facebook",

--- a/data/posts/2017-07-18-devfest-2017-announced.markdown
+++ b/data/posts/2017-07-18-devfest-2017-announced.markdown
@@ -1,8 +1,8 @@
-We're are proud to announce the fifth annual GDG DevFest 2016&mdash;the biggest Google related event in The Netherlands, carefully crafted by the GDG community! The event will take place on **October 8th** in Amsterdam.
+We're are proud to announce the fifth annual GDG DevFest 2017&mdash;the biggest Google related event in The Netherlands, carefully crafted by the GDG community! The event will take place on **November 18th** in Amsterdam.
 
 ### What to expect
 
-* In 2015 the conference was visited by **430 attendees and 20 speakers from all over the world** and we are aiming to bring you an exciting and interesting programme this year again!
+* In 2016 the conference was visited by **430 attendees and 20 speakers from all over the world** and we are aiming to bring you an exciting and interesting programme this year again!
 * Every year more than 80% of our participants are **experienced developers**. DevFest NL will as always be highly technical for both beginners and seasoned developers.
 * Three parallel lecture tracks dedicated to **Mobile**, **Web** & **Cloud** technologies.
 * Workshops where participants will have an opportunity to get some new practical skills from the best developers in Google-related technologies.
@@ -17,7 +17,7 @@ Watch our [**highlight video from GDG DevFest NL 2015**](https://www.youtube.com
 
 ### Festival organizers
 
-[Google Developer Group The Dutch Android User Group](http://dutchaug.org/) (GDG Dutch AUG) is the principal organizer of DevFest NL. GDGs aim to share experiences and gain new knowledge, and each group is an open community that organizes exciting events focused on different Google technologies with an aim share their experience and passion.
+[Google Developer Group The Dutch Android User Group](http://dutchaug.org/) (GDG DutchAUG) is the principal organizer of DevFest NL. GDGs aim to share experiences and gain new knowledge, and each group is an open community that organizes exciting events focused on different Google technologies with an aim share their experience and passion.
 
 ### Call for papers
 

--- a/data/posts/2017-08-14-calling-all-papers.markdown
+++ b/data/posts/2017-08-14-calling-all-papers.markdown
@@ -1,6 +1,6 @@
-GDG DevFest The Netherlands 2016 has been announced! The fourth annual edition of the biggest conference about Google technologies in The Netherlands will take on **October 8th** in Amsterdam.
+GDG DevFest The Netherlands 2017 has been announced! The fifth annual edition of the biggest conference about Google technologies in the Netherlands will take on **November 18th** in Amsterdam.
 
-We've opened our [call for papers](https://docs.google.com/a/dutchaug.org/forms/d/e/1FAIpQLSd6VHHL9zP3OKaPRlc7Gey-QtLxHr9Q82LHujcYBkIIQhkXpg/viewform). If you are passionate about your work or hobby and want to share your experience with the biggest tech audience in Holland, don't hesitate to send an abstract of your session our way!
+We've opened our [call for papers](https://goo.gl/qZZJxJ). If you are passionate about your work or hobby and want to share your experience with the biggest tech audience in Holland, don't hesitate to send an abstract of your session our way!
 
 <!--
 <div class="quote-container reverse">
@@ -15,7 +15,7 @@ To keep up this year, we decided to focus on the content. **We’re looking for 
 -->
 
 <div class="text-center">
-<a href="https://docs.google.com/a/dutchaug.org/forms/d/e/1FAIpQLSd6VHHL9zP3OKaPRlc7Gey-QtLxHr9Q82LHujcYBkIIQhkXpg/viewform" target="_blank" class="style-scope header-content" style="color: white; ">
+<a href="https://goo.gl/qZZJxJ" target="_blank" class="style-scope header-content" style="color: white; ">
   <paper-button class="primary style-scope header-content x-scope paper-button-0" raised="" role="button" tabindex="0" animated="" aria-disabled="false" elevation="1">Submit a proposal</paper-button>
 </a>
 </div>
@@ -24,7 +24,7 @@ To keep up this year, we decided to focus on the content. **We’re looking for 
 
 ### Why is it cool to be a speaker?
 
-Here are our top 4 reasons to [submit a proposal](https://docs.google.com/a/dutchaug.org/forms/d/e/1FAIpQLSd6VHHL9zP3OKaPRlc7Gey-QtLxHr9Q82LHujcYBkIIQhkXpg/viewform).
+Here are our top 4 reasons to [submit a proposal](https://goo.gl/qZZJxJ).
 
 1. **It's a unique challenge.** Public speaking is a magnificent skill to master!
 2. **It's good for your career.** Proving your level of expertise to a potential business partners or employers in invaluable to your professional experience.
@@ -40,6 +40,7 @@ Our team prepared set of interesting topics in but if you have any cool idea you
 * Kotlin
 * RxJava
 * Data Binding
+* Android Things
 * Testing and architecture best practices (MVP, MVVM, Clean Architecture)
 
 #### Web
@@ -62,7 +63,7 @@ Our team prepared set of interesting topics in but if you have any cool idea you
 **This call for papers will close on September 25th at 11:59 PM.**
 
 <div class="text-center">
-<a href="https://docs.google.com/a/dutchaug.org/forms/d/e/1FAIpQLSd6VHHL9zP3OKaPRlc7Gey-QtLxHr9Q82LHujcYBkIIQhkXpg/viewform" target="_blank" class="style-scope header-content" style="color: white; ">
+<a href="https://goo.gl/qZZJxJ" target="_blank" class="style-scope header-content" style="color: white; ">
   <paper-button class="primary style-scope header-content x-scope paper-button-0" raised="" role="button" tabindex="0" animated="" aria-disabled="false" elevation="1">Submit a proposal</paper-button>
 </a>
 </div>

--- a/data/posts/2017-08-14-calling-all-papers.markdown
+++ b/data/posts/2017-08-14-calling-all-papers.markdown
@@ -33,13 +33,15 @@ Here are our top 4 reasons to [submit a proposal](https://goo.gl/qZZJxJ).
 
 ### Themes and topics – what do we expect?
 
-Our team prepared set of interesting topics in but if you have any cool idea you want to share not from this list, feel free to submit it as well.
+Our team prepared a set of interesting topics in but if you have any cool idea you want to share not from this list, feel free to submit it as well.
 
 #### Android
-* New features in Nougat (multi-window, notifications, Java 8)
+* New features in 'O'
 * Kotlin
 * RxJava
 * Data Binding
+* Room
+* Lifecycle
 * Android Things
 * Testing and architecture best practices (MVP, MVVM, Clean Architecture)
 
@@ -53,6 +55,7 @@ Our team prepared set of interesting topics in but if you have any cool idea you
 #### Cloud
 * Machine Learning (TensorFlow, Vision API, Speech API, etc.)
 * Big Data (PubSub, BigQuery, Dataflow)
+* Google Cloud Functions
 * Firebase
 * Kubernetes
 
@@ -60,7 +63,7 @@ Our team prepared set of interesting topics in but if you have any cool idea you
 
 ### Deadline
 
-**This call for papers will close on September 25th at 11:59 PM.**
+**This call for papers will close on October 1st at 11:59 PM.**
 
 <div class="text-center">
 <a href="https://goo.gl/qZZJxJ" target="_blank" class="style-scope header-content" style="color: white; ">

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
         content="event, gdg, gde, devfest, google, programming, android, chrome, polymer, developers, web, cloud, androiddev, Dutch Android User Group, The Netherlands">
   <meta name="author" content="DevFestNL">
 
-  <title>GDG DevFest The Netherlands 2016</title>
+  <title>GDG DevFest The Netherlands 2017</title>
 
   <link rel="canonical" href="https://devfest.nl">
   <link rel="shortcut icon" sizes="32x32" href="images/favicon/favivon-32.png">
@@ -136,8 +136,8 @@
       "@type": "Event",
       "name": "GDG DevFest The Netherlands",
       "description": "GDG DevFest Netherlands is part of a series of GDG DevFest events all around the world",
-      "startDate": "2016-10-08T10:00:00+01:00",
-      "endDate": "2016-10-08T19:00:00+01:00",
+      "startDate": "2017-11-18T10:00:00+01:00",
+      "endDate": "2017-11-18T19:00:00+01:00",
       "url": "https://devfest.nl",
       "location": {
         "@type" : "Place",

--- a/polymer.json
+++ b/polymer.json
@@ -19,7 +19,7 @@
     "bower.json",
     "manifest.json"
   ],
-  "includeDependencies": [
+  "extraDependencies": [
     "bower_components/webcomponentsjs/webcomponents-lite.min.js"
   ]
 }

--- a/src/hoverboard-app.html
+++ b/src/hoverboard-app.html
@@ -239,7 +239,7 @@
 
         ready: function () {
           Polymer.RenderStatus.afterNextRender(this, function () {
-            HOVERBOARD.ServiceWorkerRegistration.register();
+//            HOVERBOARD.ServiceWorkerRegistration.register();
             this.importHref(this.resolveUrl('pages/schedule-page.html'), null, null, true);
             this.importHref(this.resolveUrl('pages/speakers-page.html'), null, null, true);
             this.importHref(this.resolveUrl('pages/blog-page.html'), null, null, true);


### PR DESCRIPTION
… already)

- properly link the devfest announced blog post
- remove/ update some old references to 2015/ 2016

Before we deploy this we should first iterate the topics for web/ cloud and mobile to make them more up-to-date